### PR TITLE
Enhance account display by adding optional subtype label visibility

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -11,6 +11,9 @@
 @import "./simonweb_pickr.css";
 
 @layer components {
+  .subtype-color-indicator {
+    background-color: var(--subtype-color);
+  }
   .pcr-app{
     position: static !important;
     background: none !important;

--- a/app/models/balance_sheet/account_group.rb
+++ b/app/models/balance_sheet/account_group.rb
@@ -56,6 +56,16 @@ class BalanceSheet::AccountGroup
     classification_group.currency
   end
 
+  # Returns the accountable class object for this group (e.g., Depository)
+  def accountable_class
+    @accountable_class ||= accountable_type.to_s.constantize
+  end
+
+  # Helper: map subtype to its short label using the accountable class
+  def short_subtype_label_for(subtype)
+    accountable_class.short_subtype_label_for(subtype)
+  end
+
   # Returns an array of [subtype, accounts] pairs suitable for rendering.
   # For depository (Cash), groups by subtype and sorts deterministically with
   # nil/unknown subtypes at the end. Unknown subtypes (not defined in
@@ -64,8 +74,8 @@ class BalanceSheet::AccountGroup
   def grouped_accounts
     if key == "depository"
       accounts
-        .group_by { |account| account.subtype if Depository.short_subtype_label_for(account.subtype) }
-        .sort_by { |subtype, _| [ subtype.nil? ? 1 : 0, Depository.short_subtype_label_for(subtype).to_s ] }
+        .group_by { |account| account.subtype if short_subtype_label_for(account.subtype) }
+        .sort_by { |subtype, _| [ subtype.nil? ? 1 : 0, short_subtype_label_for(subtype).to_s ] }
     else
       [ [ nil, accounts ] ]
     end

--- a/app/views/accounts/_account_row.html.erb
+++ b/app/views/accounts/_account_row.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (account:, account_group:, mobile: false) %>
+<%# locals: (account:, account_group:, mobile: false, show_subtype_label: true) %>
 
 <%= link_to account_path(account),
           class: class_names(
@@ -12,7 +12,10 @@
     <div class="flex items-center gap-2 mb-0.5">
       <%= tag.p account.name, class: class_names("text-sm text-primary font-medium truncate", "animate-pulse" => account.syncing?) %>
     </div>
-    <%= tag.p account.short_subtype_label, class: "text-sm text-secondary truncate" %>
+    <%# Only show subtype label when explicitly requested (e.g., non-Depository groups) %>
+    <% if show_subtype_label %>
+      <%= tag.p account.short_subtype_label, class: "text-xs text-secondary truncate" %>
+    <% end %>
   </div>
 
   <div class="ml-auto text-right grow h-10">

--- a/app/views/accounts/_accountable_group.html.erb
+++ b/app/views/accounts/_accountable_group.html.erb
@@ -25,13 +25,16 @@
 
     <% groups.each do |subtype, subtype_accounts| %>
       <% if subtype.present? %>
-        <div class="px-3 pt-2 text-xs font-medium text-secondary">
-          <%= Depository.short_subtype_label_for(subtype) %>
+        <div class="pl-3 pr-3 my-1">
+          <span class="inline-flex items-center gap-2 text-xs font-medium text-secondary bg-surface rounded px-2 py-0.5">
+            <span class="h-1.5 w-1.5 rounded-full subtype-color-indicator" style="--subtype-color: <%= account_group.color %>;"></span>
+            <%= account_group.short_subtype_label_for(subtype) %>
+          </span>
         </div>
       <% end %>
       <div class="space-y-1">
         <% subtype_accounts.each do |account| %>
-          <%= render "accounts/account_row", account: account, account_group: account_group, mobile: mobile %>
+          <%= render "accounts/account_row", account: account, account_group: account_group, mobile: mobile, show_subtype_label: !subtype.present? %>
         <% end %>
       </div>
     <% end %>


### PR DESCRIPTION
## Summary by Sourcery

Enhance account listing to optionally show and style subtype labels more flexibly by introducing a show_subtype_label flag, pill-style group headers with color indicators, and dynamic subtype label lookup based on the accountable type.

Enhancements:
- Display group subtype labels as styled pills with a colored dot and rounded background
- Conditionally hide account row subtype labels when the group label is shown using a new show_subtype_label flag
- Generalize subtype label retrieval to use the account_group’s accountable_type rather than hardcoding a specific class