### PR TITLE
Bump aws-sdk-s3 gem version to 1.197.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem "logtail-rails"
 gem "skylight", groups: [ :production ]
 
 # Active Storage
-gem "aws-sdk-s3", "~> 1.196.1", require: false
+gem "aws-sdk-s3", "~> 1.197.0", require: false
 gem "image_processing", ">= 1.2"
 
 # Other

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,7 +107,7 @@ GEM
     aws-sdk-kms (1.104.0)
       aws-sdk-core (~> 3, >= 3.225.0)
       aws-sigv4 (~> 1.5)
-    aws-sdk-s3 (1.196.1)
+    aws-sdk-s3 (1.197.0)
       aws-sdk-core (~> 3, >= 3.228.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.5)
@@ -642,7 +642,7 @@ DEPENDENCIES
   activerecord-import
   after_commit_everywhere (~> 1.6.0)
   apipie-rails (~> 1.4)
-  aws-sdk-s3 (~> 1.196.1)
+  aws-sdk-s3 (~> 1.197.0)
   bcrypt (~> 3.1.20)
   benchmark-ips
   bootsnap


### PR DESCRIPTION
### **PR Type**
Other


___

### **Description**
- Bump `aws-sdk-s3` gem version from 1.196.1 to 1.197.0


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Gemfile</strong><dd><code>Update aws-sdk-s3 gem version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Gemfile

- Updated `aws-sdk-s3` gem version from "~> 1.196.1" to "~> 1.197.0"


</details>


  </td>
  <td><a href="https://github.com/nikhilbadyal/maybe/pull/32/files#diff-d09ea66f8227784ff4393d88a19836f321c915ae10031d16c93d67e6283ab55f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

