### PR TITLE
Add valuations resource and create action for accounts

### DIFF
--- a/app/controllers/api/v1/valuations_controller.rb
+++ b/app/controllers/api/v1/valuations_controller.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+class Api::V1::ValuationsController < Api::V1::BaseController
+  before_action -> { authorize_scope! :write }
+
+  api :POST, "/accounts/:account_id/valuations", "Create a new valuation for an account"
+  param :account_id, String, desc: "The ID of the account", required: true
+  param :valuation, Hash, required: true do
+    param :balance, [ Float, String ], desc: "The new balance of the account (accepts numbers or numeric strings)", required: true
+    param :date, String, desc: "The date of the valuation (YYYY-MM-DD)", required: true
+  end
+  def create
+    account = current_resource_owner.family.accounts.find(params[:account_id])
+
+    # Validate account is eligible for manual valuations
+    if account.linked?
+      return render_json({
+        error: "unprocessable_entity",
+        message: "Cannot create manual valuations for linked accounts that sync data from external sources.",
+        details: "This account is connected to #{account.plaid_account&.plaid_item&.institution_name || 'an external data provider'} and receives automatic balance updates."
+      }, status: :unprocessable_entity)
+    end
+
+    unless account.active?
+      return render_json({
+        error: "unprocessable_entity",
+        message: "Cannot create valuations for inactive accounts.",
+        details: "Account status: #{account.status}"
+      }, status: :unprocessable_entity)
+    end
+
+    begin
+      balance = BigDecimal(valuation_params[:balance].to_s)
+    rescue ArgumentError => e
+      return render_json({
+        error: "unprocessable_entity",
+        message: "Invalid balance format. Please ensure balance is a valid number.",
+        details: e.message
+      }, status: :unprocessable_entity)
+    end
+
+    begin
+      date = Date.iso8601(valuation_params[:date])
+    rescue ArgumentError => e
+      return render_json({
+        error: "unprocessable_entity",
+        message: "Invalid date format. Please use YYYY-MM-DD format.",
+        details: e.message
+      }, status: :unprocessable_entity)
+    end
+
+    # Validate date business rules
+    if date > Date.current
+      return render_json({
+        error: "unprocessable_entity",
+        message: "Cannot create valuations for future dates.",
+        details: "Valuation date must be today or earlier."
+      }, status: :unprocessable_entity)
+    end
+
+    if date < account.start_date
+      return render_json({
+        error: "unprocessable_entity",
+        message: "Cannot create valuations before account start date.",
+        details: "Account start date: #{account.start_date}, provided date: #{date}"
+      }, status: :unprocessable_entity)
+    end
+
+    result = account.create_reconciliation(balance: balance, date: date)
+
+    if result.success?
+      # Find the created/updated valuation entry
+      valuation_entry = account.entries.valuations.find_by(date: date)
+
+      render_json({
+        success: true,
+        message: "Valuation created successfully.",
+        valuation: {
+          id: valuation_entry.id,
+          date: date.to_s,
+          amount: result.new_balance,
+          currency: account.currency,
+          created_at: valuation_entry.created_at,
+          updated_at: valuation_entry.updated_at
+        },
+        balance_changes: {
+          old_balance: result.old_balance,
+          new_balance: result.new_balance,
+          old_cash_balance: result.old_cash_balance,
+          new_cash_balance: result.new_cash_balance
+        }
+      }, status: :created)
+    else
+      render_json({
+        error: "unprocessable_entity",
+        message: "Failed to create valuation.",
+        details: result.error_message
+      }, status: :unprocessable_entity)
+    end
+  end
+
+  private
+
+    def valuation_params
+      params.require(:valuation).permit(:balance, :date).tap do |p|
+        p.require([ :balance, :date ])
+      end
+    end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -216,7 +216,9 @@ Rails.application.routes.draw do
       post "auth/refresh", to: "auth#refresh"
 
       # Production API endpoints
-      resources :accounts, only: [ :index ]
+      resources :accounts, only: [ :index ] do
+        resources :valuations, only: [ :create ], controller: "valuations"
+      end
       resources :transactions, only: [ :index, :show, :create, :update, :destroy ]
       resource :usage, only: [ :show ], controller: "usage"
 

--- a/test/controllers/api/v1/valuations_controller_test.rb
+++ b/test/controllers/api/v1/valuations_controller_test.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Api::V1::ValuationsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:family_admin)
+    @account = accounts(:depository)
+    @oauth_app = Doorkeeper::Application.create!(
+      name: "Test API App",
+      redirect_uri: "https://example.com/callback",
+      scopes: "read read_write"
+    )
+    @token = Doorkeeper::AccessToken.create!(
+      application: @oauth_app,
+      resource_owner_id: @user.id,
+      scopes: "read_write"
+    )
+  end
+
+  test "should create valuation with valid token and params" do
+    valuation_date = Date.current.to_s
+    assert_difference "Valuation.count", 1 do
+      post api_v1_account_valuations_url(@account),
+           params: { valuation: { balance: 1234.56, date: valuation_date } },
+           headers: { Authorization: "Bearer #{@token.token}" }
+    end
+    assert_response :created
+    assert_equal "Valuation created successfully.", JSON.parse(response.body)["message"]
+  end
+
+  test "should not create valuation with invalid token" do
+    post api_v1_account_valuations_url(@account),
+         params: { valuation: { balance: 1234.56, date: Date.current.to_s } },
+         headers: { Authorization: "Bearer invalid" }
+    assert_response :unauthorized
+  end
+
+  test "should not create valuation with insufficient scope" do
+    read_token = Doorkeeper::AccessToken.create!(
+      application: @oauth_app,
+      resource_owner_id: @user.id,
+      scopes: "read"
+    )
+    post api_v1_account_valuations_url(@account),
+         params: { valuation: { balance: 1234.56, date: Date.current.to_s } },
+         headers: { Authorization: "Bearer #{read_token.token}" }
+    assert_response :forbidden
+  end
+
+  test "should return not found for non-existent account" do
+    post api_v1_account_valuations_url("not-an-account"),
+         params: { valuation: { balance: 1234.56, date: Date.current.to_s } },
+         headers: { Authorization: "Bearer #{@token.token}" }
+    assert_response :not_found
+  end
+
+  test "should return bad request for missing params" do
+    post api_v1_account_valuations_url(@account),
+         params: { valuation: { balance: 1234.56 } }, # Missing date
+         headers: { Authorization: "Bearer #{@token.token}" }
+    assert_response :bad_request
+  end
+
+  test "returns 422 for invalid date format" do
+    post api_v1_account_valuations_url(@account),
+         params: { valuation: { balance: 1234.56, date: "15-01-2024" } },
+         headers: { Authorization: "Bearer #{@token.token}" }
+    assert_response :unprocessable_entity
+    response_body = JSON.parse(response.body)
+    assert_equal "Invalid date format. Please use YYYY-MM-DD format.", response_body["message"]
+  end
+
+  test "returns 422 for non-numeric balance" do
+    post api_v1_account_valuations_url(@account),
+         params: { valuation: { balance: "abc", date: Date.current.to_s } },
+         headers: { Authorization: "Bearer #{@token.token}" }
+    assert_response :unprocessable_entity
+    response_body = JSON.parse(response.body)
+    assert_equal "Invalid balance format. Please ensure balance is a valid number.", response_body["message"]
+  end
+
+  test "returns 400 for nil balance" do
+    post api_v1_account_valuations_url(@account),
+         params: { valuation: { balance: nil, date: Date.current.to_s } },
+         headers: { Authorization: "Bearer #{@token.token}" }
+    assert_response :bad_request
+    response_body = JSON.parse(response.body)
+    assert_equal "Required parameters are missing or invalid", response_body["message"]
+  end
+
+  test "returns 422 for inactive accounts" do
+    @account.disable!
+
+    post api_v1_account_valuations_url(@account),
+         params: { valuation: { balance: 1000.00, date: Date.current.to_s } },
+         headers: { Authorization: "Bearer #{@token.token}" }
+    assert_response :unprocessable_entity
+    response_body = JSON.parse(response.body)
+    assert_equal "Cannot create valuations for inactive accounts.", response_body["message"]
+    assert_equal "Account status: disabled", response_body["details"]
+  end
+
+  test "returns 422 for future dates" do
+    future_date = 1.day.from_now.to_date.to_s
+
+    post api_v1_account_valuations_url(@account),
+         params: { valuation: { balance: 1000.00, date: future_date } },
+         headers: { Authorization: "Bearer #{@token.token}" }
+    assert_response :unprocessable_entity
+    response_body = JSON.parse(response.body)
+    assert_equal "Cannot create valuations for future dates.", response_body["message"]
+  end
+
+  test "returns 422 for dates before account start date" do
+    start_date = @account.start_date
+    before_start_date = (start_date - 1.day).to_s
+
+    post api_v1_account_valuations_url(@account),
+         params: { valuation: { balance: 1000.00, date: before_start_date } },
+         headers: { Authorization: "Bearer #{@token.token}" }
+    assert_response :unprocessable_entity
+    response_body = JSON.parse(response.body)
+    assert_equal "Cannot create valuations before account start date.", response_body["message"]
+  end
+
+  test "returns valuation data in successful response" do
+    valuation_date = Date.current.to_s
+    post api_v1_account_valuations_url(@account),
+         params: { valuation: { balance: 1500.75, date: valuation_date } },
+         headers: { Authorization: "Bearer #{@token.token}" }
+    assert_response :created
+
+    response_body = JSON.parse(response.body)
+    assert_equal "Valuation created successfully.", response_body["message"]
+
+    # Check valuation data
+    assert response_body["valuation"].present?
+    valuation_data = response_body["valuation"]
+    assert valuation_data["id"].present?
+    assert_equal valuation_date, valuation_data["date"]
+    assert_equal "1500.75", valuation_data["amount"].to_s
+    assert_equal @account.currency, valuation_data["currency"]
+    assert valuation_data["created_at"].present?
+    assert valuation_data["updated_at"].present?
+
+    # Check balance changes data
+    assert response_body["balance_changes"].present?
+    balance_changes = response_body["balance_changes"]
+    assert_equal "1500.75", balance_changes["new_balance"].to_s
+  end
+end


### PR DESCRIPTION
## Summary by Sourcery

Introduce a new valuations endpoint to allow creating account valuations, complete with authorization checks, parameter validation, and associated integration tests

New Features:
- Add valuations resource nested under accounts with only create action
- Implement Api::V1::ValuationsController#create to authorize, validate params, and invoke account reconciliation

Documentation:
- Add API documentation for the valuations creation endpoint in the controller

Tests:
- Add integration tests for valuations endpoint covering successful creation, authorization errors, parameter validation, and missing or non-existent account scenarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added POST /api/v1/accounts/:account_id/valuations to record account valuations (params: balance, date). Requires write-scoped auth; validates numeric balance and ISO8601 date; blocks linked or inactive accounts; forbids future dates or dates before account start. Returns 201 with valuation metadata and balance_changes, or 400/401/403/404/422 errors.

- **Tests**
  - Added integration tests covering success, auth/scope errors, missing params, invalid formats, inactive/linked accounts, future and pre-start dates, and response payload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->